### PR TITLE
Fix SQLAlchemyModelFactory by using a late-configured scoped session

### DIFF
--- a/frf/app.py
+++ b/frf/app.py
@@ -127,7 +127,8 @@ def init(project_name, settings_file, base_dir, main_app=None):
         db.init(
             conf.get('SQLALCHEMY_CONNECTION_URI', 'sqlite:///:memory:'),
             echo=conf.get('SQLALCHEMY_ECHO', False),
-            use_greenlet_scope=conf.get('USING_GREENLET', False))
+            scopefunc=conf.get('SQLALCHEMY_SESSION_SCOPEFUNC', None),
+            )
 
     # set up the cache
     cache.init(conf.get(


### PR DESCRIPTION
What
----

1.  Remove the `use_greenlet_scope` param in favor of allowing the user to pass
their own scope identification function.
2.  Use a late-configured scoped session so we have a session to pass to
SQLAlchemyModelFactory's before the database is configured.

Why
---

1.  The old param was limiting, allowing the user to pass their own scopefunc is
going to allow for more flexibility.
2.  Before we had to update all the factories after the fact, and it was a hack.
This should be much better.